### PR TITLE
Disable 'Spacetime Boost' button conditionally

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
             </div>
             <table class="center" style="margin-top:20px;margin-bottom:20px"><tr>
               <td><button class="squareMediumButton layer2" onclick="superNova(1)">Spatial Launch<br><br>Spatial Compressor is x{{getSuperNovaEffect(1).beautify(2)}}<br><br>Level: {{game.supernova[0]}}{{game.bestStarTypes.gte(40)?"+"+game.supernova[3]:""}}</button></td>
-              <td><button class="squareMediumButton layer2" onclick="superNova(2)" v-if="game.bestStarTypes.gte(30)">Spacetime Boost<br><br>Gain {{getSuperNovaEffect(2).beautify()}}x spacetime<br><br><br>Level: {{game.supernova[1]}}{{game.bestStarTypes.gte(40)?"+"+game.supernova[3]:""}}</button></td>
+              <td><button class="squareMediumButton layer2" onclick="superNova(2)" v-if="game.bestStarTypes.gte(30)" v-bind:disabled="(!game.achievement.includes(47) && (game.galChal > 0 && game.galChal < 4)) || game.spaceless">Spacetime Boost<br><br>Gain {{getSuperNovaEffect(2).beautify()}}x spacetime<br><br><br>Level: {{game.supernova[1]}}{{game.bestStarTypes.gte(40)?"+"+game.supernova[3]:""}}</button></td>
               <td><button class="squareMediumButton layer2" onclick="superNova(3)" v-if="game.bestStarTypes.gte(35)">Perspective Push<br><br>Gain {{getSuperNovaEffect(3).beautify()}}x perspective power<br><br>Level: {{game.supernova[2]}}{{game.bestStarTypes.gte(40)?"+"+game.supernova[3]:""}}</button></td>
               <td><button class="squareMediumButton layer2" onclick="superNova(4)" v-if="game.bestStarTypes.gte(40)">Everything Else<br><br>Gain {{getSuperNovaEffect(4)}} free levels of all previous supernovas<br>Level: {{game.supernova[3]}}</button></td>
               

--- a/style.css
+++ b/style.css
@@ -243,3 +243,10 @@ button:not(.tabButton){
   margin: auto
 }
 
+/* To make it clear that certain buttons are disabled due to conditionals,
+   style the button differently. */
+button:disabled,
+button[disabled] {
+  background-color: #3f3f3f;
+  color: #666666;
+}


### PR DESCRIPTION
The second supernova 'Spacetime Boost' ​doesn't work if:
- you're in Spaceless. 
- if you haven't unlocked achievement "The Star Cluster of Protostars" and you're in Galaxy 1, 2, or 3.

To discourage accidental clicks, disable the button from being clicked if either conditional is true.

Also, make it such that the button looks different while disabled.

https://user-images.githubusercontent.com/76920469/103488984-c68da600-4dc5-11eb-8ac4-6f677f0b1077.mp4